### PR TITLE
Include ambient typings when compiling tests so they don't have to be…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 src/*
 test/*
 test-build/*
+typings/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-feed-parser",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "OPDS feed parser",
   "author": "NYPL",
   "repository": {
@@ -13,7 +13,7 @@
   "scripts": {
     "prepublish": "rm -rf lib; typings install; tsc",
     "test": "tslint -c tslint.json src/*.ts test/*.ts && mocha test-build/test/*.js",
-    "pretest": "tsc test/*.ts --outDir test-build --module commonjs"
+    "pretest": "tsc test/*.ts typings/main/ambient/**/*.ts --outDir test-build --module commonjs"
   },
   "devDependencies": {
     "chai": "^3.4.1",
@@ -21,7 +21,7 @@
     "mocha": "^2.3.4",
     "tslint": "^3.3.0",
     "typescript": "^1.7.5",
-    "typings": "^0.6.5"
+    "typings": "^0.6.8"
   },
   "dependencies": {
     "core-js": "^2.0.3",

--- a/src/opds_parser.ts
+++ b/src/opds_parser.ts
@@ -1,6 +1,3 @@
-///<reference path="../typings/main/ambient/core-js/core-js.d.ts" />
-///<reference path="../typings/main/ambient/xml2js/xml2js.d.ts" />
-
 import OPDSFeed from "./opds_feed";
 import NamespaceParser from "./namespace_parser";
 import FeedParser from "./feed_parser";


### PR DESCRIPTION
… referenced in the code. (Fixes #29)
