### PR TITLE
Use atom:content instead of atom:summary if it's present.

### DIFF
--- a/src/entry_parser.ts
+++ b/src/entry_parser.ts
@@ -43,16 +43,17 @@ export default class EntryParser extends Xml2jsOutputParser<OPDSEntry> {
     let published = this.parseSubtagContent(entry, atomPrefix + "published");
 
     let summaryLink;
-    let summaryContent = this.parseSubtagContent(entry, atomPrefix + "summary");
-    if (!summaryContent) {
-      summaryContent = this.parseSubtagContent(entry, atomPrefix + "content");
-    }
+    let summaryContent = this.parseSubtagContent(entry, atomPrefix + "content");
     if (!summaryContent) {
       let subtag = entry[atomPrefix + "content"];
       if (subtag && subtag.length > 0) {
         summaryLink = this.parseAttribute(subtag[0], "src");
       }
     }
+    if (!summaryContent) {
+      summaryContent = this.parseSubtagContent(entry, atomPrefix + "summary");
+    }
+
     let summary = new Summary({ content: summaryContent, link: summaryLink });
 
     let entryClass = OPDSEntry;

--- a/test/entry_parser_test.ts
+++ b/test/entry_parser_test.ts
@@ -164,6 +164,15 @@ describe("EntryParser", () => {
       expect(parsedEntry.summary.content).to.be.undefined;
     });
 
+    it("prefers summary from atom:content over atom:summary", () => {
+      let entry = {
+        "atom:summary": [{"_": "summary"}],
+        "atom:content": [{"_": "content"}]
+      };
+      let parsedEntry = parser.parse(entry);
+      expect(parsedEntry.summary.content).to.equals("content");
+    });
+
     it("extracts contributors", () => {
       let contributors = [{
         "name": [{"_": "test name"}],


### PR DESCRIPTION
This connects to https://github.com/NYPL-Simplified/opds-browser/issues/70