### PR TITLE
don't decode hrefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-feed-parser",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OPDS feed parser",
   "author": "NYPL",
   "repository": {

--- a/src/link_parser.ts
+++ b/src/link_parser.ts
@@ -15,7 +15,7 @@ import Xml2jsOutputParser from "./xml2js_output_parser";
 
 export default class LinkParser extends Xml2jsOutputParser<OPDSLink> {
   parse(link: any): OPDSLink {
-    let href = decodeURIComponent(this.parseAttribute(link, "href"));
+    let href = this.parseAttribute(link, "href");
     let rel = this.parseAttribute(link, "rel");
     let type = this.parseAttribute(link, "type");
     let title = this.parseAttribute(link, "title");

--- a/test/link_parser_test.ts
+++ b/test/link_parser_test.ts
@@ -29,14 +29,14 @@ describe("LinkParser", () => {
     it("extracts link attributes", () => {
       let link = {
         "$": {
-          "href": {"value": "test%20href"},
+          "href": {"value": "test href"},
           "rel":  {"value": "test rel"},
           "type": {"value": "test type"},
           "title": {"value": "test title"}
         }
       };
       let parsedLink = parser.parse(link);
-      expect(parsedLink.href).to.equals("test href"); // url should be decoded
+      expect(parsedLink.href).to.equals("test href");
       expect(parsedLink.rel).to.equals("test rel");
       expect(parsedLink.type).to.equals("test type");
       expect(parsedLink.title).to.equals("test title");


### PR DESCRIPTION
This branch undoes the foolish 830f5dd603b1eda880866ddfca5b00196e258542 and increments the package version.