### PR TITLE
Added role to link parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-feed-parser",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "OPDS feed parser",
   "author": "NYPL",
   "repository": {

--- a/src/link_parser.ts
+++ b/src/link_parser.ts
@@ -23,6 +23,7 @@ export default class LinkParser extends Xml2jsOutputParser<OPDSLink> {
     let rel = this.parseAttribute(link, "rel");
     let type = this.parseAttribute(link, "type");
     let title = this.parseAttribute(link, "title");
+    let role = this.parseAttribute(link, "role");
 
     if (rel === OPDSCatalogRootLink.REL) {
        return new OPDSCatalogRootLink({ href, type, title });
@@ -70,7 +71,7 @@ export default class LinkParser extends Xml2jsOutputParser<OPDSLink> {
     } else if (rel === OPDSShelfLink.REL) {
       return new OPDSShelfLink({ href, rel });
     } else {
-      return new OPDSLink({ href, rel, type, title });
+      return new OPDSLink({ href, rel, type, title, role });
     }
   }
 

--- a/src/opds_link.ts
+++ b/src/opds_link.ts
@@ -3,6 +3,7 @@ export default class OPDSLink {
   rel: string;
   type: string;
   title: string;
+  role: string;
 
   constructor(args: OPDSLinkArgs) {
     Object.assign(this, args);
@@ -14,4 +15,5 @@ export interface OPDSLinkArgs {
   type?: string;
   title?: string;
   rel?: string;
+  role?: string;
 }

--- a/test/link_parser_test.ts
+++ b/test/link_parser_test.ts
@@ -38,7 +38,8 @@ describe("LinkParser", () => {
           "href": {"value": "test href"},
           "rel":  {"value": "test rel"},
           "type": {"value": "test type"},
-          "title": {"value": "test title"}
+          "title": {"value": "test title"},
+          "role": {"value": "test role"}
         }
       };
       let parsedLink = parser.parse(link);
@@ -46,9 +47,10 @@ describe("LinkParser", () => {
       expect(parsedLink.rel).to.equals("test rel");
       expect(parsedLink.type).to.equals("test type");
       expect(parsedLink.title).to.equals("test title");
+      expect(parsedLink.role).to.equals("test role");
     });
 
-    it("allows no type and title", () => {
+    it("allows no type, title, and role", () => {
       let link = {
         "$": {
           "href": {"value": "test href"},
@@ -60,6 +62,7 @@ describe("LinkParser", () => {
       expect(parsedLink.rel).to.equals("test rel");
       expect(parsedLink.type).to.be.undefined;
       expect(parsedLink.title).to.be.undefined;
+      expect(parsedLink.role).to.be.undefined;
     });
 
     it("extracts catalog root link", () => {


### PR DESCRIPTION
This makes it possible to use the "navigation" role to locate header links in the OPDS feed for https://github.com/NYPL-Simplified/circulation-patron-web/pull/56.